### PR TITLE
fix: set mCommand

### DIFF
--- a/src/ios/ListLibraryItems.m
+++ b/src/ios/ListLibraryItems.m
@@ -95,7 +95,8 @@ static NSString * PERMISSION_ERROR = @"Permission Denial: This application is no
     NSString * uploadUrl  = payload[@"serverUrl"];
     NSDictionary * headers = payload[@"headers"];
     NSString * libraryId = payload[@"libraryId"];
-    
+	
+    mCommand = command;
     
     // try to fetch asset
     PHFetchResult<PHAsset *> * assets = [PHAsset fetchAssetsWithLocalIdentifiers:@[libraryId] options:kNilOptions];


### PR DESCRIPTION
The [mCommand](https://github.com/cozy/cordova-plugin-list-library-items/blob/1b2749c64f068156863344692d27faf07d285d88/src/ios/ListLibraryItems.m#L11) variable is declared and used [here](https://github.com/cozy/cordova-plugin-list-library-items/blob/1b2749c64f068156863344692d27faf07d285d88/src/ios/ListLibraryItems.m#L284) for example, but it's never set.
This causes the `aCommand` variable to be `nil` [in the callback](https://github.com/cozy/cordova-plugin-list-library-items/blob/1b2749c64f068156863344692d27faf07d285d88/src/ios/ListLibraryItems.m#L83) and the js callbacks are not triggered.
Not sure this fix was the intended use, but it fixes the problem!

@maestun do you mind taking a look at this?