### PR TITLE
fix: allow network access while saving photos

### DIFF
--- a/src/ios/ListLibraryItems.m
+++ b/src/ios/ListLibraryItems.m
@@ -113,7 +113,7 @@ static NSString * PERMISSION_ERROR = @"Permission Denial: This application is no
             mLocalTempURL = [NSURL fileURLWithPath:temp_path];
             [[NSFileManager defaultManager] removeItemAtURL:mLocalTempURL error:nil]; // cleanup
             PHAssetResourceRequestOptions * options = [PHAssetResourceRequestOptions new];
-            [options setNetworkAccessAllowed: NO];
+            [options setNetworkAccessAllowed: YES];
             [options setProgressHandler:^(double progress) {
                 NSLog(@"progress %f", progress);
             }];


### PR DESCRIPTION
This option allows to download a file from iCloud if it's not on the device yet.