### PR TITLE
fix: use read(byte[]) instead of read(byte[], int, int)

### DIFF
--- a/src/android/io/cozy/plugins/listlibraryitems/ListLibraryItems.java
+++ b/src/android/io/cozy/plugins/listlibraryitems/ListLibraryItems.java
@@ -314,7 +314,7 @@ public class ListLibraryItems extends CordovaPlugin {
                 buffer_size = 4 * 1024;
                 buffer = new byte[buffer_size];
                 total_bytes = 0;
-                while ((bytes_read = fis.read(buffer, 0, bytes_read)) != -1) {
+                while ((bytes_read = fis.read(buffer)) != -1) {
                     out.write(buffer, 0, bytes_read);
                     total_bytes += bytes_read;
                     publishProgress(buffer_size, total_bytes, FILE_SZ);


### PR DESCRIPTION
see https://github.com/cozy/cordova-plugin-list-library-items/pull/7#discussion_r161724727