### PR TITLE
fix: cast file size to int to publish progress

### DIFF
--- a/src/android/io/cozy/plugins/listlibraryitems/ListLibraryItems.java
+++ b/src/android/io/cozy/plugins/listlibraryitems/ListLibraryItems.java
@@ -317,7 +317,7 @@ public class ListLibraryItems extends CordovaPlugin {
                 while ((bytes_read = fis.read(buffer)) != -1) {
                     out.write(buffer, 0, bytes_read);
                     total_bytes += bytes_read;
-                    publishProgress(buffer_size, total_bytes, FILE_SZ);
+                    publishProgress(buffer_size, total_bytes, (int) FILE_SZ);
                 }
                 out.flush();
                 out.close();


### PR DESCRIPTION
`publishProgress ` expects `Integers` but `FILE_SZ ` is now a `long`.