### PR TITLE
fix: use fixed-length streaming mode

### DIFF
--- a/src/android/io/cozy/plugins/listlibraryitems/ListLibraryItems.java
+++ b/src/android/io/cozy/plugins/listlibraryitems/ListLibraryItems.java
@@ -306,7 +306,7 @@ public class ListLibraryItems extends CordovaPlugin {
                 huc.setDoInput(true);
                 huc.setDoOutput(true);
                 huc.setRequestMethod("POST");
-                huc.setChunkedStreamingMode(1024 * 1000);
+                huc.setFixedLengthStreamingMode(FILE_SZ);
                 huc.setInstanceFollowRedirects(true);
 
                 // read input file chunks + publish progress


### PR DESCRIPTION
Using `setChunkedStreamingMode` removed the `Content-Length` header, but since we know the file size in advance there's really no reason to use it.