### PR TITLE
fix: better mime type support

### DIFF
--- a/src/ios/ListLibraryItems.m
+++ b/src/ios/ListLibraryItems.m
@@ -238,6 +238,8 @@ static NSString * PERMISSION_ERROR = @"Permission Denial: This application is no
                     mimeType = @"audio/wav";
                 } else if ([[fullPath pathExtension] rangeOfString:@"css"].location != NSNotFound) {
                     mimeType = @"text/css";
+                } else {
+                    mimeType = @"application/octet-stream";
                 }
             }
             CFRelease(typeId);

--- a/src/ios/ListLibraryItems.m
+++ b/src/ios/ListLibraryItems.m
@@ -238,6 +238,10 @@ static NSString * PERMISSION_ERROR = @"Permission Denial: This application is no
                     mimeType = @"audio/wav";
                 } else if ([[fullPath pathExtension] rangeOfString:@"css"].location != NSNotFound) {
                     mimeType = @"text/css";
+                } else if ([[fullPath pathExtension] rangeOfString:@"heic"].location != NSNotFound) {
+                    mimeType = @"image/heic";
+                } else if ([[fullPath pathExtension] rangeOfString:@"heif"].location != NSNotFound) {
+                    mimeType = @"image/heif";
                 } else {
                     mimeType = @"application/octet-stream";
                 }


### PR DESCRIPTION
- In certain cases, `mimeType` could end up being `nil` which caused a crash
- on older iOS versions, `heic` and `heif` files don't return a mime type, so we manually handle them