### PR TITLE
fix: use lowercase version of filename extension to get MIME type

### DIFF
--- a/src/android/io/cozy/plugins/listlibraryitems/ListLibraryItems.java
+++ b/src/android/io/cozy/plugins/listlibraryitems/ListLibraryItems.java
@@ -266,7 +266,7 @@ public class ListLibraryItems extends CordovaPlugin {
         String type = null;
         String extension = MimeTypeMap.getFileExtensionFromUrl(url);
         if (extension != null) {
-            type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+            type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension.toLowerCase());
         }
         return type;
     }


### PR DESCRIPTION
Androids MimeTypeMap#getFileExtensionFromUrl() could not handle
uppercase file extensions, so that a file named "DSC_001.JPG" returns a
`null` MIME type.